### PR TITLE
Introduce login screen before home navigation

### DIFF
--- a/app/src/main/java/ru/example/canlisu/MainActivity.kt
+++ b/app/src/main/java/ru/example/canlisu/MainActivity.kt
@@ -1,14 +1,11 @@
 package ru.example.canlisu
 
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.isVisible
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import ru.example.canlisu.databinding.ActivityMainBinding
 // Если делаешь DataStore "запомнить меня":
 // import ru.example.canlisu.prefs.AuthPrefs
@@ -23,16 +20,21 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         val navController = supportFragmentManager
-            .findFragmentById(R.id.nav_home)
+            .findFragmentById(R.id.nav_host_fragment_content_main)
             ?.findNavController()
             ?: error("NavHostFragment not found")
 
         binding.bottomNav.setupWithNavController(navController)
+
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            binding.bottomNav.visibility =
+                if (destination.id == R.id.loginFragment) View.GONE else View.VISIBLE
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {
         // Без AppBarConfiguration:
-        val navController = findNavController(R.id.bottomNav)
-        return navController.navigateUp()
+        val navController = findNavController(R.id.nav_host_fragment_content_main)
+        return navController.navigateUp() || super.onSupportNavigateUp()
     }
 }

--- a/app/src/main/java/ru/example/canlisu/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/LoginFragment.kt
@@ -1,0 +1,38 @@
+package ru.example.canlisu.ui.auth
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import ru.example.canlisu.databinding.FragmentLoginBinding
+import ru.example.canlisu.R
+
+class LoginFragment : Fragment() {
+
+    private var _binding: FragmentLoginBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: LoginViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentLoginBinding.inflate(inflater, container, false)
+
+        binding.signInButton.setOnClickListener {
+            findNavController().navigate(R.id.action_loginFragment_to_nav_home)
+        }
+
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/ru/example/canlisu/ui/auth/LoginViewModel.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/LoginViewModel.kt
@@ -1,0 +1,9 @@
+package ru.example.canlisu.ui.auth
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class LoginViewModel : ViewModel() {
+    val email = MutableLiveData<String>()
+    val password = MutableLiveData<String>()
+}

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -31,7 +31,11 @@
         android:id="@+id/loginFragment"
         android:name="ru.example.canlisu.ui.auth.LoginFragment"
         android:label="Login"
-        tools:layout="@layout/fragment_login" />
+        tools:layout="@layout/fragment_login">
+        <action
+            android:id="@+id/action_loginFragment_to_nav_home"
+            app:destination="@id/nav_home" />
+    </fragment>
 
     <fragment
         android:id="@+id/requestFragment"


### PR DESCRIPTION
## Summary
- Launch app on new `LoginFragment` and navigate to Home after sign-in
- Hide bottom navigation on login screen and show it afterwards

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab181ed883219696da0e784390e7