### PR TITLE
Add subscription change and registration screens

### DIFF
--- a/app/src/main/java/ru/example/canlisu/MainActivity.kt
+++ b/app/src/main/java/ru/example/canlisu/MainActivity.kt
@@ -1,14 +1,11 @@
 package ru.example.canlisu
 
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.isVisible
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import ru.example.canlisu.databinding.ActivityMainBinding
 // Если делаешь DataStore "запомнить меня":
 // import ru.example.canlisu.prefs.AuthPrefs
@@ -23,16 +20,21 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         val navController = supportFragmentManager
-            .findFragmentById(R.id.nav_home)
+            .findFragmentById(R.id.nav_host_fragment_content_main)
             ?.findNavController()
             ?: error("NavHostFragment not found")
 
         binding.bottomNav.setupWithNavController(navController)
+
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            val hideBottom = destination.id == R.id.loginFragment || destination.id == R.id.registrationFragment
+            binding.bottomNav.visibility = if (hideBottom) View.GONE else View.VISIBLE
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {
         // Без AppBarConfiguration:
-        val navController = findNavController(R.id.bottomNav)
-        return navController.navigateUp()
+        val navController = findNavController(R.id.nav_host_fragment_content_main)
+        return navController.navigateUp() || super.onSupportNavigateUp()
     }
 }

--- a/app/src/main/java/ru/example/canlisu/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/LoginFragment.kt
@@ -1,0 +1,42 @@
+package ru.example.canlisu.ui.auth
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import ru.example.canlisu.databinding.FragmentLoginBinding
+import ru.example.canlisu.R
+
+class LoginFragment : Fragment() {
+
+    private var _binding: FragmentLoginBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: LoginViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentLoginBinding.inflate(inflater, container, false)
+
+        binding.signInButton.setOnClickListener {
+            findNavController().navigate(R.id.action_loginFragment_to_nav_home)
+        }
+
+        binding.createAccountButton.setOnClickListener {
+            findNavController().navigate(R.id.action_loginFragment_to_registrationFragment)
+        }
+
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/ru/example/canlisu/ui/auth/LoginViewModel.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/LoginViewModel.kt
@@ -1,0 +1,9 @@
+package ru.example.canlisu.ui.auth
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class LoginViewModel : ViewModel() {
+    val email = MutableLiveData<String>()
+    val password = MutableLiveData<String>()
+}

--- a/app/src/main/java/ru/example/canlisu/ui/auth/RegistrationFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/RegistrationFragment.kt
@@ -1,0 +1,39 @@
+package ru.example.canlisu.ui.auth
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import ru.example.canlisu.R
+import ru.example.canlisu.databinding.FragmentRegistrationBinding
+
+class RegistrationFragment : Fragment() {
+
+    private var _binding: FragmentRegistrationBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: RegistrationViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentRegistrationBinding.inflate(inflater, container, false)
+
+        binding.signUpButton.setOnClickListener {
+            findNavController().navigate(R.id.action_registrationFragment_to_nav_home)
+        }
+
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}
+

--- a/app/src/main/java/ru/example/canlisu/ui/auth/RegistrationViewModel.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/RegistrationViewModel.kt
@@ -1,0 +1,13 @@
+package ru.example.canlisu.ui.auth
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class RegistrationViewModel : ViewModel() {
+    val firstName = MutableLiveData<String>()
+    val lastName = MutableLiveData<String>()
+    val email = MutableLiveData<String>()
+    val address = MutableLiveData<String>()
+    val cardNumber = MutableLiveData<String>()
+}
+

--- a/app/src/main/java/ru/example/canlisu/ui/gallery/ChangeSubscriptionFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/gallery/ChangeSubscriptionFragment.kt
@@ -1,0 +1,35 @@
+package ru.example.canlisu.ui.gallery
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import ru.example.canlisu.databinding.FragmentChangeSubscriptionBinding
+
+class ChangeSubscriptionFragment : Fragment() {
+
+    private var _binding: FragmentChangeSubscriptionBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentChangeSubscriptionBinding.inflate(inflater, container, false)
+
+        binding.confirmButton.setOnClickListener {
+            findNavController().navigateUp()
+        }
+
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}
+

--- a/app/src/main/java/ru/example/canlisu/ui/gallery/SubscriptionFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/gallery/SubscriptionFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import ru.example.canlisu.databinding.FragmentSubscriptionBinding
 import ru.example.canlisu.R
 
@@ -31,6 +32,9 @@ class SubscriptionFragment : Fragment() {
             subNameView.text = getString(R.string.subscription_name, subscriptionName)
             monthlyPaymentView.text = getString(R.string.monthly_payment, monthlyPayment)
             lastBilledView.text = getString(R.string.last_billing_date, lastBillingDate)
+            changeSubscriptionButton.setOnClickListener {
+                findNavController().navigate(R.id.action_nav_gallery_to_changeSubscriptionFragment)
+            }
         }
 
         return binding.root

--- a/app/src/main/java/ru/example/canlisu/ui/home/HomeFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/home/HomeFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import ru.example.canlisu.databinding.FragmentHomeBinding
 import ru.example.canlisu.R
 
@@ -43,8 +44,10 @@ class HomeFragment : Fragment() {
             emailView.text = getString(R.string.email_template, email)
             addressView.text = getString(R.string.address_template, address)
             cardNumberMasked.text = getString(R.string.card_number_template, last4Digits)
+        }
 
-
+        binding.logoutButton.setOnClickListener {
+            findNavController().navigate(R.id.action_nav_home_to_loginFragment)
         }
         binding.swipeRefreshLayout.setOnRefreshListener {
             // TODO: обновить данные здесь (например, запрос в ViewModel)

--- a/app/src/main/res/layout/fragment_change_subscription.xml
+++ b/app/src/main/res/layout/fragment_change_subscription.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.gallery.ChangeSubscriptionFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/choose_subscription"
+            android:textStyle="bold"
+            android:textSize="20sp"
+            android:layout_marginBottom="16dp"/>
+
+        <RadioGroup
+            android:id="@+id/subscriptionGroup"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <RadioButton
+                android:id="@+id/optionMini"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/sub_option_mini"
+                android:layout_marginBottom="8dp"/>
+
+            <RadioButton
+                android:id="@+id/optionStandard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/sub_option_standard"
+                android:layout_marginBottom="8dp"/>
+
+            <RadioButton
+                android:id="@+id/optionPremium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/sub_option_premium"/>
+        </RadioGroup>
+
+        <Button
+            android:id="@+id/confirmButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/confirm_subscription_change"
+            android:background="@drawable/rounded_button"
+            android:textColor="@android:color/white"/>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -70,6 +70,15 @@ tools:context=".ui.home.HomeFragment">
                         android:text="@string/address_template"
                         android:paddingBottom="8dp"/>
 
+                    <Button
+                        android:id="@+id/logoutButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/logout"
+                        android:background="@drawable/rounded_button"
+                        android:textColor="@android:color/white" />
+
                     <!-- Divider -->
                     <View
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_registration.xml
+++ b/app/src/main/res/layout/fragment_registration.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.auth.RegistrationFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/register_title"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="16dp"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/register_first_name_label"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/firstNameInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/register_last_name_label"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_marginTop="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/lastNameInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/register_email_label"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_marginTop="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/emailInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textEmailAddress"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/register_address_label"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_marginTop="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/addressInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/register_card_label"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_marginTop="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/cardInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/signUpButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/register_sign_up"
+            android:background="@drawable/rounded_button"
+            android:textColor="@android:color/white"/>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_subscription.xml
+++ b/app/src/main/res/layout/fragment_subscription.xml
@@ -44,7 +44,7 @@
             android:layout_height="wrap_content"
             android:text="@string/last_billing_date" />
         <Button
-            android:id="@+id/addPaymentMethodButton"
+            android:id="@+id/changeSubscriptionButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -3,19 +3,27 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mobile_navigation"
-    app:startDestination="@id/loginFragment">
+    app:startDestination="@id/nav_home">
 
     <fragment
         android:id="@+id/nav_home"
         android:name="ru.example.canlisu.ui.home.HomeFragment"
         android:label="Home"
-        tools:layout="@layout/fragment_home" />
+        tools:layout="@layout/fragment_home">
+        <action
+            android:id="@+id/action_nav_home_to_loginFragment"
+            app:destination="@id/loginFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_gallery"
         android:name="ru.example.canlisu.ui.gallery.SubscriptionFragment"
         android:label="@string/menu_subscription"
-        tools:layout="@layout/fragment_subscription" />
+        tools:layout="@layout/fragment_subscription">
+        <action
+            android:id="@+id/action_nav_gallery_to_changeSubscriptionFragment"
+            app:destination="@id/changeSubscriptionFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_slideshow"
@@ -31,7 +39,30 @@
         android:id="@+id/loginFragment"
         android:name="ru.example.canlisu.ui.auth.LoginFragment"
         android:label="Login"
-        tools:layout="@layout/fragment_login" />
+        tools:layout="@layout/fragment_login">
+        <action
+            android:id="@+id/action_loginFragment_to_nav_home"
+            app:destination="@id/nav_home" />
+        <action
+            android:id="@+id/action_loginFragment_to_registrationFragment"
+            app:destination="@id/registrationFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/registrationFragment"
+        android:name="ru.example.canlisu.ui.auth.RegistrationFragment"
+        android:label="Registration"
+        tools:layout="@layout/fragment_registration">
+        <action
+            android:id="@+id/action_registrationFragment_to_nav_home"
+            app:destination="@id/nav_home" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/changeSubscriptionFragment"
+        android:name="ru.example.canlisu.ui.gallery.ChangeSubscriptionFragment"
+        android:label="Change Subscription"
+        tools:layout="@layout/fragment_change_subscription" />
 
     <fragment
         android:id="@+id/requestFragment"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -19,12 +19,24 @@
     <string name="subscription_name">Подписка: %1$s</string>
     <string name="monthly_payment">Ежемесячный платеж: %1$s</string>
     <string name="last_billing_date">Последний платеж: %1$s</string>
+    <string name="choose_subscription">Выберите подписку</string>
+    <string name="confirm_subscription_change">Подтвердить</string>
+    <string name="sub_option_mini">Живая вода \"мини\" - 990₽/месяц</string>
+    <string name="sub_option_standard">Живая вода \"стандарт\" - 1290₽/месяц</string>
+    <string name="sub_option_premium">Живая вода \"премиум\" - 1990₽/месяц</string>
     <string name="requests_title">Запросы</string>
     <string name="create_new_request">Создать новый запрос</string>
     <string name="describe_issue">Опишите проболему</string>
     <string name="hint_issue_description">Подробно опишите проблему...</string>
     <string name="hint_contact_number">Контактный номер телефона</string>
     <string name="submit_request">Отправить</string>
+    <string name="register_title">Создать аккаунт</string>
+    <string name="register_first_name_label">Имя</string>
+    <string name="register_last_name_label">Фамилия</string>
+    <string name="register_email_label">Эл. почта</string>
+    <string name="register_address_label">Адрес</string>
+    <string name="register_card_label">Номер карты</string>
+    <string name="register_sign_up">Зарегистрироваться</string>
     <string name="menu_subscription">Подписки</string>
     <string name="menu_help">Помощь</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="nav_header_subtitle" translatable="false">name.example@android.com</string>
     <string name="nav_header_desc" translatable="false">Navigation header</string>
     <string name="action_settings">Settings</string>
-    <string name="logout">Logout</string>
+    <string name="logout">Выход</string>
     <string name="full_name" translatable="false">%1$s</string>
 
     <string name="menu_profile">Profile</string>
@@ -29,6 +29,11 @@
     <string name="subscription_name">Subscription: %1$s</string>
     <string name="monthly_payment">Monthly Payment: %1$s</string>
     <string name="last_billing_date">Last Billed: %1$s</string>
+    <string name="choose_subscription">Choose Subscription</string>
+    <string name="confirm_subscription_change">Confirm</string>
+    <string name="sub_option_mini">Live water \"mini\" - 990₽/month</string>
+    <string name="sub_option_standard">Live water \"standard\" - 1290₽/month</string>
+    <string name="sub_option_premium">Live water \"premium\" - 1990₽/month</string>
 
     <string name="requests_title">Requests</string>
     <string name="create_new_request">Create New Request</string>
@@ -48,6 +53,14 @@
     <string name="login_sign_in" translatable="false">Sign In</string>
     <string name="login_or" translatable="false">or</string>
     <string name="login_create_account" translatable="false">Create Account</string>
+
+    <string name="register_title" translatable="false">Create Account</string>
+    <string name="register_first_name_label" translatable="false">First Name</string>
+    <string name="register_last_name_label" translatable="false">Last Name</string>
+    <string name="register_email_label" translatable="false">Email</string>
+    <string name="register_address_label" translatable="false">Address</string>
+    <string name="register_card_label" translatable="false">Card Number</string>
+    <string name="register_sign_up" translatable="false">Sign Up</string>
 
 
 


### PR DESCRIPTION
## Summary
- Provide change subscription flow with three selectable plans
- Introduce registration screen to collect user information
- Hook login and subscription pages to new destinations and hide bottom nav on auth pages

## Testing
- `bash gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab181ed883219696da0e784390e7