### PR TITLE
Add validation for registration and login fields

### DIFF
--- a/app/src/main/java/ru/example/canlisu/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/LoginFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.util.Patterns
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -25,7 +26,13 @@ class LoginFragment : Fragment() {
         _binding = FragmentLoginBinding.inflate(inflater, container, false)
 
         binding.signInButton.setOnClickListener {
-            findNavController().navigate(R.id.action_loginFragment_to_nav_home)
+            val email = binding.emailInput.text?.toString()?.trim() ?: ""
+            if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+                binding.emailLayout.error = getString(R.string.error_invalid_email)
+            } else {
+                binding.emailLayout.error = null
+                findNavController().navigate(R.id.action_loginFragment_to_nav_home)
+            }
         }
 
         binding.createAccountButton.setOnClickListener {

--- a/app/src/main/java/ru/example/canlisu/ui/auth/RegistrationFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/RegistrationFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.util.Patterns
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -25,7 +26,37 @@ class RegistrationFragment : Fragment() {
         _binding = FragmentRegistrationBinding.inflate(inflater, container, false)
 
         binding.signUpButton.setOnClickListener {
-            findNavController().navigate(R.id.action_registrationFragment_to_nav_home)
+            val firstName = binding.firstNameInput.text?.toString()?.trim() ?: ""
+            val lastName = binding.lastNameInput.text?.toString()?.trim() ?: ""
+            val email = binding.emailInput.text?.toString()?.trim() ?: ""
+
+            val nameRegex = Regex("^[А-Яа-яЁё]+$")
+            var isValid = true
+
+            if (!nameRegex.matches(firstName)) {
+                binding.firstNameLayout.error = getString(R.string.error_invalid_name)
+                isValid = false
+            } else {
+                binding.firstNameLayout.error = null
+            }
+
+            if (!nameRegex.matches(lastName)) {
+                binding.lastNameLayout.error = getString(R.string.error_invalid_name)
+                isValid = false
+            } else {
+                binding.lastNameLayout.error = null
+            }
+
+            if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+                binding.emailLayout.error = getString(R.string.error_invalid_email)
+                isValid = false
+            } else {
+                binding.emailLayout.error = null
+            }
+
+            if (isValid) {
+                findNavController().navigate(R.id.action_registrationFragment_to_nav_home)
+            }
         }
 
         return binding.root

--- a/app/src/main/res/layout/fragment_registration.xml
+++ b/app/src/main/res/layout/fragment_registration.xml
@@ -22,6 +22,7 @@
             android:layout_marginBottom="16dp"/>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/firstNameLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/register_first_name_label"
@@ -33,6 +34,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/lastNameLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/register_last_name_label"
@@ -45,6 +47,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/emailLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/register_email_label"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,7 +62,8 @@
     <string name="register_card_label" translatable="false">Card Number</string>
     <string name="register_sign_up" translatable="false">Sign Up</string>
 
-
+    <string name="error_invalid_name">Допустимы только буквы кириллицы</string>
+    <string name="error_invalid_email">Некорректный email</string>
 
     <string name="menu_subscription">Subscription</string>
     <string name="menu_help">Help</string>


### PR DESCRIPTION
## Summary
- enforce Cyrillic-only names and proper email format during registration
- check email format before login

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a10245e09083219b05ba6c2bb6710e