### PR TITLE
Handle missing Supabase client configuration

### DIFF
--- a/app/src/main/java/ru/example/canlisu/data/SubscriptionRepository.kt
+++ b/app/src/main/java/ru/example/canlisu/data/SubscriptionRepository.kt
@@ -10,18 +10,22 @@ import io.github.jan.supabase.postgrest.select
 class SubscriptionRepository(
     private val client: SupabaseClient? = SupabaseClientProvider.client,
 ) {
-    suspend fun getAvailableSubscriptions(): List<Subscription> {
-        val supabase = client ?: throw IllegalStateException("Supabase client is not configured")
-        return supabase.postgrest["subscriptions"].select().decodeList<Subscription>()
+    suspend fun getAvailableSubscriptions(): Result<List<Subscription>> {
+        val supabase = client ?: return Result.failure(IllegalStateException("Supabase client is not configured"))
+        return runCatching {
+            supabase.postgrest["subscriptions"].select().decodeList<Subscription>()
+        }
     }
 
-    suspend fun getActiveSubscriptions(userId: Int): List<UserSubscription> {
-        val supabase = client ?: throw IllegalStateException("Supabase client is not configured")
-        return supabase.postgrest["user_subscriptions"].select {
-            filter {
-                eq("user_id", userId)
-                eq("active", true)
-            }
-        }.decodeList<UserSubscription>()
+    suspend fun getActiveSubscriptions(userId: Int): Result<List<UserSubscription>> {
+        val supabase = client ?: return Result.failure(IllegalStateException("Supabase client is not configured"))
+        return runCatching {
+            supabase.postgrest["user_subscriptions"].select {
+                filter {
+                    eq("user_id", userId)
+                    eq("active", true)
+                }
+            }.decodeList<UserSubscription>()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- return `Result` from auth and subscription repositories when Supabase client is missing
- surface Supabase configuration issues in login and registration view models

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a61a8f754083219142c646cd3d1e67