### PR TITLE
Refactor Supabase client initialization for tests

### DIFF
--- a/app/src/test/java/ru/example/canlisu/data/TodoRepositoryTest.kt
+++ b/app/src/test/java/ru/example/canlisu/data/TodoRepositoryTest.kt
@@ -9,9 +9,7 @@ class TodoRepositoryTest {
 
     @Before
     fun setup() {
-        val delegateField = SupabaseClientProvider::class.java.getDeclaredField("client\$delegate")
-        delegateField.isAccessible = true
-        delegateField.set(null, lazy { null })
+        SupabaseClientProvider.clearForTests()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- refactor SupabaseClientProvider to use a mutable, lazily initialized client with `initClientIfNeeded`
- add `clearForTests` to disable initialization for unit tests
- update TodoRepositoryTest to reset the provider via `clearForTests`
