### PR TITLE
Add password recovery and refine login error handling

### DIFF
--- a/app/src/main/java/ru/example/canlisu/data/AuthExceptions.kt
+++ b/app/src/main/java/ru/example/canlisu/data/AuthExceptions.kt
@@ -1,0 +1,4 @@
+package ru.example.canlisu.data
+
+class UserNotFoundException : Exception("user_not_found")
+class InvalidPasswordException : Exception("invalid_password")

--- a/app/src/main/java/ru/example/canlisu/data/SupabaseClientProvider.kt
+++ b/app/src/main/java/ru/example/canlisu/data/SupabaseClientProvider.kt
@@ -9,36 +9,26 @@ import ru.example.canlisu.BuildConfig
 
 object SupabaseClientProvider {
 
-    @Volatile
-    private var _client: SupabaseClient? = null
-    @Volatile
-    private var allowInit: Boolean = true
-
-    val client: SupabaseClient?
-        get() {
-            initClientIfNeeded()
-            return _client
-        }
-
-    private fun initClientIfNeeded() {
-        if (!allowInit || _client != null) return
+    val client: SupabaseClient? by lazy {
         val url = BuildConfig.SUPABASE_URL
         val key = BuildConfig.SUPABASE_KEY
         if (url.isBlank() || key.isBlank()) {
             Log.e("SupabaseClientProvider", "Supabase credentials are missing")
-            return
-        }
-        _client = createSupabaseClient(
-            supabaseUrl = url,
-            supabaseKey = key
-        ) {
-            install(Postgrest)
-            install(Auth)
+            null
+        } else {
+            createSupabaseClient(
+                supabaseUrl = url,
+                supabaseKey = key
+            ) {
+                install(Postgrest)
+                install(Auth)
+            }
         }
     }
 
     fun clearForTests() {
-        _client = null
-        allowInit = false
+        val field = SupabaseClientProvider::class.java.getDeclaredField("client\$delegate")
+        field.isAccessible = true
+        field.set(null, lazy<SupabaseClient?> { null })
     }
 }

--- a/app/src/main/java/ru/example/canlisu/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/LoginFragment.kt
@@ -38,6 +38,7 @@ class LoginFragment : Fragment() {
                 is AuthState.Success -> {
                     binding.progressBar.visibility = View.GONE
                     binding.signInButton.isEnabled = true
+                    binding.emailLayout.error = null
                     binding.passwordLayout.error = null
                     binding.passwordInput.text?.clear()
                     findNavController().navigate(R.id.action_loginFragment_to_nav_home)
@@ -45,14 +46,24 @@ class LoginFragment : Fragment() {
                 is AuthState.Error -> {
                     binding.progressBar.visibility = View.GONE
                     binding.signInButton.isEnabled = true
-                    if (state.message == "invalid_credentials") {
-                        binding.passwordLayout.error = getString(R.string.error_invalid_password)
-                    } else {
-                        Snackbar.make(
-                            binding.root,
-                            state.message.ifEmpty { getString(R.string.error_network) },
-                            Snackbar.LENGTH_LONG
-                        ).show()
+                    when (state.message) {
+                        "user_not_found" -> {
+                            binding.emailLayout.error = getString(R.string.error_user_not_found)
+                            binding.passwordLayout.error = null
+                        }
+                        "invalid_password" -> {
+                            binding.passwordLayout.error = getString(R.string.error_invalid_password)
+                            binding.emailLayout.error = null
+                        }
+                        else -> {
+                            binding.emailLayout.error = null
+                            binding.passwordLayout.error = null
+                            Snackbar.make(
+                                binding.root,
+                                state.message.ifEmpty { getString(R.string.error_network) },
+                                Snackbar.LENGTH_LONG
+                            ).show()
+                        }
                     }
                 }
             }
@@ -78,6 +89,10 @@ class LoginFragment : Fragment() {
 
         binding.createAccountButton.setOnClickListener {
             findNavController().navigate(R.id.action_loginFragment_to_registrationFragment)
+        }
+
+        binding.forgotLink.setOnClickListener {
+            findNavController().navigate(R.id.action_loginFragment_to_passwordRecoveryFragment)
         }
 
         return binding.root

--- a/app/src/main/java/ru/example/canlisu/ui/auth/PasswordRecoveryFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/PasswordRecoveryFragment.kt
@@ -1,0 +1,77 @@
+package ru.example.canlisu.ui.auth
+
+import android.os.Bundle
+import android.util.Patterns
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.snackbar.Snackbar
+import ru.example.canlisu.R
+import ru.example.canlisu.data.AuthRepository
+import ru.example.canlisu.databinding.FragmentPasswordRecoveryBinding
+
+class PasswordRecoveryFragment : Fragment() {
+
+    private var _binding: FragmentPasswordRecoveryBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: PasswordRecoveryViewModel by viewModels {
+        PasswordRecoveryViewModelFactory(AuthRepository())
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentPasswordRecoveryBinding.inflate(inflater, container, false)
+
+        viewModel.resetState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                AuthState.Loading -> {
+                    binding.progressBar.visibility = View.VISIBLE
+                    binding.sendButton.isEnabled = false
+                }
+                is AuthState.Success -> {
+                    binding.progressBar.visibility = View.GONE
+                    binding.sendButton.isEnabled = true
+                    Snackbar.make(
+                        binding.root,
+                        getString(R.string.password_recovery_success),
+                        Snackbar.LENGTH_LONG
+                    ).show()
+                    findNavController().navigate(R.id.action_passwordRecoveryFragment_to_loginFragment)
+                }
+                is AuthState.Error -> {
+                    binding.progressBar.visibility = View.GONE
+                    binding.sendButton.isEnabled = true
+                    Snackbar.make(
+                        binding.root,
+                        state.message.ifEmpty { getString(R.string.error_network) },
+                        Snackbar.LENGTH_LONG
+                    ).show()
+                }
+            }
+        }
+
+        binding.sendButton.setOnClickListener {
+            val email = binding.emailInput.text?.toString()?.trim() ?: ""
+            if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+                binding.emailLayout.error = getString(R.string.error_invalid_email)
+            } else {
+                binding.emailLayout.error = null
+                viewModel.resetPassword(email)
+            }
+        }
+
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/ru/example/canlisu/ui/auth/PasswordRecoveryViewModel.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/PasswordRecoveryViewModel.kt
@@ -1,0 +1,31 @@
+package ru.example.canlisu.ui.auth
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import ru.example.canlisu.data.AuthRepository
+
+class PasswordRecoveryViewModel(private val repository: AuthRepository) : ViewModel() {
+
+    private val _resetState = MutableLiveData<AuthState<Unit>>()
+    val resetState: LiveData<AuthState<Unit>> = _resetState
+
+    fun resetPassword(email: String) {
+        viewModelScope.launch {
+            _resetState.value = AuthState.Loading
+            repository.resetPassword(email)
+                .onSuccess {
+                    _resetState.value = AuthState.Success(Unit)
+                }
+                .onFailure { e ->
+                    _resetState.value = if (e is IllegalStateException) {
+                        AuthState.Error("Supabase client is not configured. Please configure Supabase.")
+                    } else {
+                        AuthState.Error(e.message ?: "Network error")
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/ru/example/canlisu/ui/auth/PasswordRecoveryViewModelFactory.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/auth/PasswordRecoveryViewModelFactory.kt
@@ -1,0 +1,15 @@
+package ru.example.canlisu.ui.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import ru.example.canlisu.data.AuthRepository
+
+class PasswordRecoveryViewModelFactory(private val repository: AuthRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(PasswordRecoveryViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return PasswordRecoveryViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/res/layout/fragment_password_recovery.xml
+++ b/app/src/main/res/layout/fragment_password_recovery.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp"
+    tools:context=".ui.auth.PasswordRecoveryFragment">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/emailLayout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/password_recovery_email_label"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/emailInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textEmailAddress"
+            android:imeOptions="actionDone"/>
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <Button
+        android:id="@+id/sendButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/password_recovery_send"
+        android:textAllCaps="false"
+        android:textStyle="bold"
+        android:background="@drawable/rounded_button"
+        android:textColor="@android:color/white"
+        app:layout_constraintTop_toBottomOf="@id/emailLayout"
+        app:layout_constraintStart_toStartOf="@id/emailLayout"
+        app:layout_constraintEnd_toEndOf="@id/emailLayout"
+        android:layout_marginTop="16dp"/>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -52,6 +52,9 @@
         <action
             android:id="@+id/action_loginFragment_to_registrationFragment"
             app:destination="@id/registrationFragment" />
+        <action
+            android:id="@+id/action_loginFragment_to_passwordRecoveryFragment"
+            app:destination="@id/passwordRecoveryFragment" />
     </fragment>
 
     <fragment
@@ -63,6 +66,18 @@
             android:id="@+id/action_registrationFragment_to_nav_home"
             app:destination="@id/nav_home"
             app:popUpTo="@id/loginFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/passwordRecoveryFragment"
+        android:name="ru.example.canlisu.ui.auth.PasswordRecoveryFragment"
+        android:label="Password Recovery"
+        tools:layout="@layout/fragment_password_recovery">
+        <action
+            android:id="@+id/action_passwordRecoveryFragment_to_loginFragment"
+            app:destination="@id/loginFragment"
+            app:popUpTo="@id/passwordRecoveryFragment"
             app:popUpToInclusive="true" />
     </fragment>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,8 +72,13 @@
     <string name="error_invalid_phone" translatable="false">Некорректный номер телефона</string>
     <string name="error_invalid_email_or_phone" translatable="false">Некорректный email или номер телефона</string>
     <string name="error_invalid_password" translatable="false">Invalid password</string>
+    <string name="error_user_not_found" translatable="false">User not found</string>
     <string name="register_password_label" translatable="false">Password</string>
     <string name="error_network" translatable="false">Network error</string>
+
+    <string name="password_recovery_email_label" translatable="false">Email</string>
+    <string name="password_recovery_send" translatable="false">Send</string>
+    <string name="password_recovery_success" translatable="false">If an account exists with that email, we’ve sent reset instructions.</string>
 
     <string name="menu_subscription">Обслуживание</string>
     <string name="menu_help">Поддержка</string>


### PR DESCRIPTION
## Summary
- Distinguish unknown user and wrong password cases
- Add Supabase password reset support and UI
- Wire navigation to new password recovery screen
- Simplify Supabase client initialization to match Supabase docs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed2465d1883218bed1d197330e885