### PR TITLE
Add example request card to Help screen

### DIFF
--- a/app/src/main/java/ru/example/canlisu/ui/slideshow/HelpFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/slideshow/HelpFragment.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.Fragment
+import com.google.android.material.chip.Chip
 import androidx.navigation.fragment.findNavController
 import ru.example.canlisu.R
 import ru.example.canlisu.databinding.FragmentHelpBinding
@@ -28,6 +30,15 @@ class HelpFragment : Fragment() {
         }
 
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val number = (10000..99999).random()
+        val card = view.findViewById<View>(R.id.exampleRequest)
+        card.findViewById<TextView>(R.id.tvRequestNumber).text = "№ $number"
+        card.findViewById<TextView>(R.id.tvRequestTitle).text = "Протечка трубы"
+        card.findViewById<Chip>(R.id.chipStatus).text = "Исполнен"
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout/fragment_help.xml
+++ b/app/src/main/res/layout/fragment_help.xml
@@ -19,12 +19,19 @@
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginBottom="8dp" />
 
+    <include
+        android:id="@+id/exampleRequest"
+        layout="@layout/item_request"
+        app:layout_constraintTop_toBottomOf="@id/requestsTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <!-- Список заявок -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/requestsRecyclerView"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/requestsTitle"
+        app:layout_constraintTop_toBottomOf="@id/exampleRequest"
         app:layout_constraintBottom_toTopOf="@id/createRequestButton"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/item_request.xml
+++ b/app/src/main/res/layout/item_request.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    android:clickable="true"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardCornerRadius="16dp"
+    app:strokeWidth="1dp"
+    app:useCompatPadding="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:gravity="center_vertical"
+        android:weightSum="1">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tvRequestNumber"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="№ 10423"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvRequestTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Протечка трубы"
+                android:maxLines="1"
+                android:ellipsize="end" />
+        </LinearLayout>
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/chipStatus"
+            style="@style/Widget.MaterialComponents.Chip.Assist"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:text="Исполнен"
+            android:textAllCaps="false"
+            android:textColor="@android:color/white"
+            app:chipBackgroundColor="@color/status_done"
+            app:chipIconVisible="false"
+            app:chipStrokeWidth="0dp" />
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,4 +13,5 @@
     <color name="bottom_nav_inactive">@color/gray</color>
 
     <color name="bottom_nav_background">@color/white</color>
+    <color name="status_done">#4CAF50</color>
 </resources>


### PR DESCRIPTION
## Summary
- add reusable `item_request` card layout
- show example request card in `fragment_help`
- populate example card with random number and sample data
- define `status_done` color for chip background