### PR TITLE
Load subscriptions from Supabase

### DIFF
--- a/app/src/main/java/ru/example/canlisu/data/Subscription.kt
+++ b/app/src/main/java/ru/example/canlisu/data/Subscription.kt
@@ -9,7 +9,11 @@ import kotlinx.serialization.Serializable
 data class Subscription(
     val id: Int,
     val name: String,
+    val description: String,
     val price: Double,
-    @SerialName("duration_months")
-    val durationMonths: Int
+    @SerialName("duration_days")
+    val durationDays: Int,
+    @SerialName("physicalUser")
+    val physicalUser: Int,
+    val discount: Int? = null
 )

--- a/app/src/main/java/ru/example/canlisu/data/SubscriptionPlan.kt
+++ b/app/src/main/java/ru/example/canlisu/data/SubscriptionPlan.kt
@@ -4,6 +4,7 @@ package ru.example.canlisu.data
  * Model describing a subscription plan option displayed on the subscriptions screen.
  */
 data class SubscriptionPlan(
+    val id: Int,
     val title: String,
     val price: String,
     val oldPrice: String? = null,

--- a/app/src/main/java/ru/example/canlisu/data/UserSubscription.kt
+++ b/app/src/main/java/ru/example/canlisu/data/UserSubscription.kt
@@ -7,14 +7,13 @@ import kotlinx.serialization.Serializable
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class UserSubscription(
-    val id: Int,
+    val id: String,
     @SerialName("user_id")
-    val userId: Int,
+    val userId: String,
     @SerialName("subscription_id")
     val subscriptionId: Int,
     @SerialName("start_date")
     val startDate: String,
-    @SerialName("end_date")
-    val endDate: String? = null,
-    val active: Boolean = false
+    @SerialName("is_active")
+    val isActive: Boolean = false
 )

--- a/app/src/main/java/ru/example/canlisu/ui/gallery/SubscriptionDetailFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/gallery/SubscriptionDetailFragment.kt
@@ -1,0 +1,46 @@
+package ru.example.canlisu.ui.gallery
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import ru.example.canlisu.data.SubscriptionRepository
+import ru.example.canlisu.databinding.FragmentSubscriptionDetailBinding
+
+class SubscriptionDetailFragment : Fragment() {
+
+    private var _binding: FragmentSubscriptionDetailBinding? = null
+    private val binding get() = _binding!!
+    private val repository = SubscriptionRepository()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentSubscriptionDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val id = requireArguments().getInt("subscriptionId")
+        viewLifecycleOwner.lifecycleScope.launch {
+            repository.getSubscriptionById(id).onSuccess { sub ->
+                binding.titleView.text = sub.name
+                binding.descriptionView.text = sub.description
+                binding.priceView.text = "${sub.price.toInt()} ₽"
+            }
+        }
+
+        binding.continueButton.setOnClickListener { }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/ru/example/canlisu/ui/gallery/SubscriptionFragment.kt
+++ b/app/src/main/java/ru/example/canlisu/ui/gallery/SubscriptionFragment.kt
@@ -5,20 +5,21 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import ru.example.canlisu.databinding.FragmentSubscriptionBinding
+import kotlinx.coroutines.launch
 import ru.example.canlisu.R
+import ru.example.canlisu.prefs.AuthPrefs
+import ru.example.canlisu.data.SubscriptionRepository
+import ru.example.canlisu.data.UserSubscription
+import ru.example.canlisu.databinding.FragmentSubscriptionBinding
 
 class SubscriptionFragment : Fragment() {
 
     private var _binding: FragmentSubscriptionBinding? = null
     private val binding get() = _binding!!
 
-    // Примерные данные подписки (можно потом подгружать с API или ViewModel)
-    private val subscriptionStatus = "Active"
-    private val subscriptionName = "Live water \"mini\""
-    private val monthlyPayment = "990₽"
-    private val lastBillingDate = "2025-07-15"
+    private val repository = SubscriptionRepository()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -26,18 +27,56 @@ class SubscriptionFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSubscriptionBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val user = AuthPrefs.getUser(requireContext())
+        val userId = user?.id
+        if (userId == null) {
+            showNoSubscription()
+            return
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            repository.getActiveSubscription(userId).onSuccess { sub ->
+                if (sub != null && sub.isActive) {
+                    showSubscription(sub)
+                } else {
+                    showNoSubscription()
+                }
+            }.onFailure {
+                showNoSubscription()
+            }
+        }
+    }
+
+    private fun showSubscription(sub: UserSubscription) {
         binding.apply {
-            subStatusView.text = getString(R.string.subscription_status, subscriptionStatus)
-            subNameView.text = getString(R.string.subscription_name, subscriptionName)
-            monthlyPaymentView.text = getString(R.string.monthly_payment, monthlyPayment)
-            lastBilledView.text = getString(R.string.last_billing_date, lastBillingDate)
+            subStatusView.text = getString(R.string.subscription_status, if (sub.isActive) "Активна" else "Не активна")
+            subNameView.text = "ID подписки: ${sub.subscriptionId}"
+            monthlyPaymentView.text = "ID записи: ${sub.id}"
+            lastBilledView.text = "Дата начала: ${sub.startDate}"
+            monthlyPaymentView.visibility = View.VISIBLE
+            lastBilledView.visibility = View.VISIBLE
+            changeSubscriptionButton.text = getString(R.string.change_subscription)
             changeSubscriptionButton.setOnClickListener {
                 findNavController().navigate(R.id.action_nav_gallery_to_changeSubscriptionFragment)
             }
         }
+    }
 
-        return binding.root
+    private fun showNoSubscription() {
+        binding.apply {
+            subStatusView.text = "У вас еще нет активной подписки"
+            subNameView.text = "Хотите выбрать?"
+            monthlyPaymentView.visibility = View.GONE
+            lastBilledView.visibility = View.GONE
+            changeSubscriptionButton.text = getString(R.string.choose_subscription)
+            changeSubscriptionButton.setOnClickListener {
+                findNavController().navigate(R.id.action_nav_gallery_to_changeSubscriptionFragment)
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout/fragment_subscription_detail.xml
+++ b/app/src/main/res/layout/fragment_subscription_detail.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.gallery.SubscriptionDetailFragment">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/detailCard"
+        style="@style/SectionCard"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_margin="16dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/titleView"
+                style="@style/SectionTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+            <TextView
+                android:id="@+id/descriptionView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"/>
+
+            <TextView
+                android:id="@+id/priceView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"/>
+
+            <Button
+                android:id="@+id/continueButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/rounded_button"
+                android:text="@string/continue_button"/>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -85,7 +85,17 @@
         android:id="@+id/changeSubscriptionFragment"
         android:name="ru.example.canlisu.ui.gallery.ChangeSubscriptionFragment"
         android:label="Change Subscription"
-        tools:layout="@layout/fragment_change_subscription" />
+        tools:layout="@layout/fragment_change_subscription">
+        <action
+            android:id="@+id/action_changeSubscriptionFragment_to_subscriptionDetailFragment"
+            app:destination="@id/subscriptionDetailFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/subscriptionDetailFragment"
+        android:name="ru.example.canlisu.ui.gallery.SubscriptionDetailFragment"
+        android:label="Subscription Detail"
+        tools:layout="@layout/fragment_subscription_detail" />
     <fragment
         android:id="@+id/requestFragment"
         android:name="ru.example.canlisu.ui.request.RequestFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,4 +92,5 @@
     <string name="tab_home">Home</string>
     <string name="tab_business">Business</string>
     <string name="select_plan">Select Plan</string>
+    <string name="continue_button">Продолжить</string>
 </resources>


### PR DESCRIPTION
## Summary
- Fetch subscriptions and user status from Supabase tables
- Navigate to subscription details screen with data loaded by ID
- Add layout and strings for viewing a subscription plan

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c19440161c8321ae229b0e973fc407